### PR TITLE
Always show pie-charts on teasers if available

### DIFF
--- a/components/List/Teaser/Charts.js
+++ b/components/List/Teaser/Charts.js
@@ -62,15 +62,15 @@ const Chart = styled.div`
 `;
 
 const TeaserCharts = ({ voteResults, procedure, currentStatus, isCanceled }) => {
-  const votes = voteResults.yes + voteResults.no + voteResults.notVoted + voteResults.abstination;
-  let voteCount = voteResults.namedVote ? `${votes} Abgeordnete` : '6 Fraktionen';
+  const votes = voteResults ? voteResults.yes + voteResults.no + voteResults.notVoted + voteResults.abstination : null;
+  let voteCount = votes ? voteResults.namedVote ? `${votes} Abgeordnete` : '6 Fraktionen': null;
 
   if (isCanceled) voteCount = currentStatus;
 
   return (
     <Wrapper>
       <Container>
-        {(voteResults.yes > 0 || voteResults.no > 0 || isCanceled) && (
+        {!!voteResults && (voteResults.yes > 0 || voteResults.no > 0 || isCanceled) && (
           <>
             <ChartWrapper>
               <ChartLegend>
@@ -110,54 +110,54 @@ const TeaserCharts = ({ voteResults, procedure, currentStatus, isCanceled }) => 
                 )}
               </Chart>
             </ChartWrapper>
-            <Query
-              query={COMMUNITY_VOTES}
-              variables={{
-                procedure,
-              }}
-            >
-              {({ data }) => {
-                if (!data.communityVotes) {
-                  return <div />;
-                }
-                const communityVoteCount =
-                  data.communityVotes.yes +
-                  data.communityVotes.abstination +
-                  data.communityVotes.no;
-                return (
-                  <ChartWrapper>
-                    <ChartLegend>
-                      <ChartLegendTitle>Community</ChartLegendTitle>
-                      <ChartLegendDescription>
-                        {communityVoteCount} Abstimmende
-                      </ChartLegendDescription>
-                    </ChartLegend>
-                    <Chart>
-                      <PieChart
-                        key="partyChart"
-                        data={_.map(
-                          data.communityVotes,
-                          (value, label) =>
-                            label !== '__typename' && typeof value === 'number'
-                              ? {
-                                  value,
-                                  label,
-                                  fractions: null,
-                                  percentage: Math.round((value / communityVoteCount) * 100),
-                                }
-                              : false,
-                        ).filter(e => e)}
-                        colorScale={['#15C063', '#2C82E4', '#EC3E31']}
-                        label="Abgeordnete"
-                        voteResults={voteResults}
-                      />
-                    </Chart>
-                  </ChartWrapper>
-                );
-              }}
-            </Query>
           </>
         )}
+        <Query
+          query={COMMUNITY_VOTES}
+          variables={{
+            procedure,
+          }}
+        >
+          {({ data }) => {
+            if (!data.communityVotes) {
+              return <div />;
+            }
+            const communityVoteCount =
+              data.communityVotes.yes +
+              data.communityVotes.abstination +
+              data.communityVotes.no;
+            return (
+              <ChartWrapper>
+                <ChartLegend>
+                  <ChartLegendTitle>Community</ChartLegendTitle>
+                  <ChartLegendDescription>
+                    {communityVoteCount} Abstimmende
+                  </ChartLegendDescription>
+                </ChartLegend>
+                <Chart>
+                  <PieChart
+                    key="partyChart"
+                    data={_.map(
+                      data.communityVotes,
+                      (value, label) =>
+                        label !== '__typename' && typeof value === 'number'
+                          ? {
+                            value,
+                            label,
+                            fractions: null,
+                            percentage: Math.round((value / communityVoteCount) * 100),
+                          }
+                          : false,
+                    ).filter(e => e)}
+                    colorScale={['#15C063', '#2C82E4', '#EC3E31']}
+                    label="Abgeordnete"
+                    voteResults={voteResults}
+                  />
+                </Chart>
+              </ChartWrapper>
+            );
+          }}
+        </Query>
       </Container>
     </Wrapper>
   );

--- a/components/List/Teaser/Charts.js
+++ b/components/List/Teaser/Charts.js
@@ -1,10 +1,6 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import _ from 'lodash';
-import { Query } from 'react-apollo';
-
-// GraphQL
-import COMMUNITY_VOTES from 'GraphQl/queries/communityVotes';
 
 // Components
 import PieChart from './PieChart';
@@ -61,21 +57,24 @@ const Chart = styled.div`
   margin-right: 5px;
 `;
 
-const TeaserCharts = ({ voteResults, procedure, currentStatus, isCanceled }) => {
-  const votes = voteResults ? voteResults.yes + voteResults.no + voteResults.notVoted + voteResults.abstination : null;
-  let voteCount = votes ? voteResults.namedVote ? `${votes} Abgeordnete` : '6 Fraktionen': null;
+const TeaserCharts = ({ communityVotes, voteResults, currentStatus, isCanceled }) => {
+  const hasCommunityVotes = !!communityVotes;
+  const hasPartyVotes = !!voteResults && (voteResults.yes > 0 || voteResults.no > 0 || isCanceled);
+  const communityVoteCount = communityVotes ? communityVotes.yes + communityVotes.no + communityVotes.abstination : null;
+  const partyVoteCount = hasPartyVotes ? voteResults.yes + voteResults.no + voteResults.abstination + voteResults.notVoted : null;
 
-  if (isCanceled) voteCount = currentStatus;
+  let partyVoteDesc = hasPartyVotes ? voteResults.namedVote ? `${partyVoteCount} Abgeordnete` : '6 Fraktionen' : null;
+  partyVoteDesc = isCanceled ? currentStatus : partyVoteDesc;
 
   return (
     <Wrapper>
       <Container>
-        {!!voteResults && (voteResults.yes > 0 || voteResults.no > 0 || isCanceled) && (
-          <>
+        <>
+          {hasPartyVotes && (
             <ChartWrapper>
               <ChartLegend>
                 <ChartLegendTitle>Bundestag</ChartLegendTitle>
-                <ChartLegendDescription>{voteCount}</ChartLegendDescription>
+                <ChartLegendDescription>{partyVoteDesc}</ChartLegendDescription>
               </ChartLegend>
               <Chart>
                 {!isCanceled ? (
@@ -93,13 +92,12 @@ const TeaserCharts = ({ voteResults, procedure, currentStatus, isCanceled }) => 
                                 : voteResults.partyVotes.filter(
                                     ({ main }) => label === main.toLowerCase(),
                                   ).length,
-                              percentage: Math.round((value / votes) * 100),
+                              percentage: Math.round((value / partyVoteCount) * 100),
                             }
                           : false,
                     ).filter(e => e)}
                     colorScale={['#99C93E', '#4CB0D8', '#D43194', '#B1B3B4']}
                     label="Abgeordnete"
-                    voteResults={voteResults}
                   />
                 ) : (
                   <PieChartCanceled
@@ -110,62 +108,45 @@ const TeaserCharts = ({ voteResults, procedure, currentStatus, isCanceled }) => 
                 )}
               </Chart>
             </ChartWrapper>
-          </>
-        )}
-        <Query
-          query={COMMUNITY_VOTES}
-          variables={{
-            procedure,
-          }}
-        >
-          {({ data }) => {
-            if (!data.communityVotes) {
-              return <div />;
-            }
-            const communityVoteCount =
-              data.communityVotes.yes +
-              data.communityVotes.abstination +
-              data.communityVotes.no;
-            return (
-              <ChartWrapper>
-                <ChartLegend>
-                  <ChartLegendTitle>Community</ChartLegendTitle>
-                  <ChartLegendDescription>
-                    {communityVoteCount} Abstimmende
-                  </ChartLegendDescription>
-                </ChartLegend>
-                <Chart>
-                  <PieChart
-                    key="partyChart"
-                    data={_.map(
-                      data.communityVotes,
-                      (value, label) =>
-                        label !== '__typename' && typeof value === 'number'
-                          ? {
-                            value,
-                            label,
-                            fractions: null,
-                            percentage: Math.round((value / communityVoteCount) * 100),
-                          }
-                          : false,
-                    ).filter(e => e)}
-                    colorScale={['#15C063', '#2C82E4', '#EC3E31']}
-                    label="Abgeordnete"
-                    voteResults={voteResults}
-                  />
-                </Chart>
-              </ChartWrapper>
-            );
-          }}
-        </Query>
+          )}
+          {hasCommunityVotes && (
+            <ChartWrapper>
+              <ChartLegend>
+                <ChartLegendTitle>Community</ChartLegendTitle>
+                <ChartLegendDescription>
+                  {communityVoteCount} Abstimmende
+                </ChartLegendDescription>
+              </ChartLegend>
+              <Chart>
+                <PieChart
+                  key="partyChart"
+                  data={_.map(
+                    communityVotes,
+                    (value, label) =>
+                      label !== '__typename' && typeof value === 'number'
+                        ? {
+                          value,
+                          label,
+                          fractions: null,
+                          percentage: Math.round((value / communityVoteCount) * 100),
+                        }
+                        : false,
+                  ).filter(e => e)}
+                  colorScale={['#15C063', '#2C82E4', '#EC3E31']}
+                  label="Abgeordnete"
+                />
+              </Chart>
+            </ChartWrapper>
+          )}
+        </>
       </Container>
     </Wrapper>
   );
 };
 
 TeaserCharts.propTypes = {
+  communityVotes: PropTypes.shape().isRequired,
   voteResults: PropTypes.shape().isRequired,
-  procedure: PropTypes.string,
   currentStatus: PropTypes.string,
   isCanceled: PropTypes.bool,
 };

--- a/components/List/Teaser/index.js
+++ b/components/List/Teaser/index.js
@@ -99,10 +99,10 @@ const Teaser = ({
                     <Image src={`${getImage(subjectGroups[0])}_648.jpg`} alt={subjectGroups[0]} />
                   </ImageContainer>
                   <Charts
-                        procedure={procedureId}
-                        voteResults={voteResults}
-                        currentStatus={currentStatus}
-                        isCanceled={isCanceled}
+                    procedure={procedureId}
+                    voteResults={voteResults}
+                    currentStatus={currentStatus}
+                    isCanceled={isCanceled}
                   />
                 </>
               }

--- a/components/List/Teaser/index.js
+++ b/components/List/Teaser/index.js
@@ -98,15 +98,12 @@ const Teaser = ({
                   <ImageContainer>
                     <Image src={`${getImage(subjectGroups[0])}_648.jpg`} alt={subjectGroups[0]} />
                   </ImageContainer>
-                  {listType === 'vergangen' &&
-                    !!voteResults && (
-                      <Charts
+                  <Charts
                         procedure={procedureId}
                         voteResults={voteResults}
                         currentStatus={currentStatus}
                         isCanceled={isCanceled}
-                      />
-                    )}
+                  />
                 </>
               }
             >

--- a/components/List/Teaser/index.js
+++ b/components/List/Teaser/index.js
@@ -39,12 +39,11 @@ const Image = styled.img`
   width: 100%;
 `;
 
-// Do not pass listType and hoverEffect to DOM
+// Do not pass listType to DOM
 // eslint-disable-next-line no-unused-vars
-const Card = styled(({ listType, hoverEffect, ...props }) => <CardComponent {...props} />)`
+const Card = styled(({ listType, ...props }) => <CardComponent {...props} />)`
   &:hover ${Image} {
-    filter: ${({ listType, hoverEffect }) =>
-      listType === 'vergangen' && hoverEffect ? 'blur(2px) brightness(0.7)' : 'none'};
+    filter: blur(2px) brightness(0.7);
   }
   &:hover ${ChartLegendTitle}, &:hover ${ChartLegendDescription} {
     display: block;
@@ -63,6 +62,7 @@ const Teaser = ({
   procedureId,
   type,
   activityIndex,
+  communityVotes,
   voteDate,
   subjectGroups,
   voteResults,
@@ -85,9 +85,6 @@ const Teaser = ({
               onClick={() => changeSearchTerm('')}
               hoverable
               listType={listType}
-              hoverEffect={
-                !!voteResults && (voteResults.yes > 0 || voteResults.no > 0 || isCanceled)
-              }
               cover={
                 <>
                   {voteDate && (
@@ -99,7 +96,7 @@ const Teaser = ({
                     <Image src={`${getImage(subjectGroups[0])}_648.jpg`} alt={subjectGroups[0]} />
                   </ImageContainer>
                   <Charts
-                    procedure={procedureId}
+                    communityVotes={communityVotes}
                     voteResults={voteResults}
                     currentStatus={currentStatus}
                     isCanceled={isCanceled}
@@ -167,6 +164,7 @@ Teaser.propTypes = {
   procedureId: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   activityIndex: PropTypes.shape().isRequired,
+  communityVotes: PropTypes.shape().isRequired,
   voteDate: PropTypes.string,
   subjectGroups: PropTypes.array.isRequired,
   voteResults: PropTypes.shape().isRequired,

--- a/graphql/queries/procedures.js
+++ b/graphql/queries/procedures.js
@@ -21,6 +21,11 @@ export default gql`
       activityIndex {
         activityIndex
       }
+      communityVotes {
+        yes
+        no
+        abstination
+      }
       voteDate
       subjectGroups
       currentStatus

--- a/graphql/queries/searchProcedures.js
+++ b/graphql/queries/searchProcedures.js
@@ -11,6 +11,16 @@ export default gql`
           activityIndex
         }
         voteDate
+        voteResults {
+        	yes
+        	no
+        	abstination
+        	notVoted
+        	namedVote
+        	partyVotes {
+          		main
+        	}
+      	}
         subjectGroups
       }
       autocomplete

--- a/graphql/queries/searchProcedures.js
+++ b/graphql/queries/searchProcedures.js
@@ -10,6 +10,11 @@ export default gql`
         activityIndex {
           activityIndex
         }
+        communityVotes {
+          yes
+          no
+          abstination
+        }
         voteDate
         voteResults {
           yes

--- a/graphql/queries/searchProcedures.js
+++ b/graphql/queries/searchProcedures.js
@@ -12,15 +12,15 @@ export default gql`
         }
         voteDate
         voteResults {
-        	yes
-        	no
-        	abstination
-        	notVoted
-        	namedVote
-        	partyVotes {
-          		main
-        	}
-      	}
+          yes
+          no
+          abstination
+          notVoted
+          namedVote
+          partyVotes {
+            main
+          }
+        }
         subjectGroups
       }
       autocomplete


### PR DESCRIPTION
## Pullrequest
Always shows pie-charts on teasers if available

### Todo
- [X] Currently the **voteResults** are gathered with one initial query, while the **communityVotes** are gathered with multiple sub queries. Maybe it would be more efficient to add the communityVotes to the initial request.
- [X] Always show the **hoverEffect** on all teasers.